### PR TITLE
Call the next, not the default

### DIFF
--- a/jsonAPI/JsonApiMiddleware.php
+++ b/jsonAPI/JsonApiMiddleware.php
@@ -80,10 +80,10 @@ class JsonApiMiddleware extends \Slim\Middleware {
     }
 
     /**
-     * Call default SLIM call()
+     * Call next
      */
     function call(){
-        return $this->app->call();
+        return $this->next->call();
     }
 
     static function _errorType($type=1){


### PR DESCRIPTION
In the call for the middleware you need to use $this->next->call() so that it continues the chain instead of $this->app->call().  This pull request fixes it.
