### PR TITLE
Add flash messages to the response

### DIFF
--- a/jsonAPI/JsonApiView.php
+++ b/jsonAPI/JsonApiView.php
@@ -39,7 +39,12 @@ class JsonApiView extends \Slim\View {
         $response['status'] = $status;
 
         //add flash messages
-        $response['flash'] = $this->data->flash->getMessages();
+        $flash = $this->data->flash->getMessages();
+        if (count($flash)) {
+            $response['flash'] = $flash;   
+        } else {
+            unset($response['flash']);
+        }
 
         $app->response()->status($status);
         $app->response()->header('Content-Type', 'application/json');


### PR DESCRIPTION
$this->data->flash is a Slim flash object, thus json_encode($this->all()) results in { 'flash': {}, ...} instead of the actual messages.  This pull request, puts $this->all() into $response, then adds the actual messages ($this->data->flash->getMessages()) to $response['flash'], and json_encodes($response).  The result is { 'flash': {'your flash key': 'your flash message', ...} ... }.  Now you can use flash messages in your app and return them in the json.
