### PR TITLE
Add a parameter for json encoding

### DIFF
--- a/jsonAPI/JsonApiView.php
+++ b/jsonAPI/JsonApiView.php
@@ -23,6 +23,22 @@
  */
 class JsonApiView extends \Slim\View {
 
+    /**
+     * Bitmask consisting of <b>JSON_HEX_QUOT</b>,
+     * <b>JSON_HEX_TAG</b>,
+     * <b>JSON_HEX_AMP</b>,
+     * <b>JSON_HEX_APOS</b>,
+     * <b>JSON_NUMERIC_CHECK</b>,
+     * <b>JSON_PRETTY_PRINT</b>,
+     * <b>JSON_UNESCAPED_SLASHES</b>,
+     * <b>JSON_FORCE_OBJECT</b>,
+     * <b>JSON_UNESCAPED_UNICODE</b>.
+     * The behaviour of these constants is described on
+     * the JSON constants page.
+     * @var int
+     */
+    public $encodingOptions = 0;
+
     public function render($status=200, $data = NULL) {
         $app = \Slim\Slim::getInstance();
 
@@ -54,9 +70,9 @@ class JsonApiView extends \Slim\View {
         $jsonp_callback = $app->request->get('callback', null);
 
         if($jsonp_callback !== null){
-            $app->response()->body($jsonp_callback.'('.json_encode($response).')');
+            $app->response()->body($jsonp_callback.'('.json_encode($response, $this->encodingOptions).')');
         } else {
-            $app->response()->body(json_encode($response));
+            $app->response()->body(json_encode($response, $this->encodingOptions));
         }
 
         $app->stop();


### PR DESCRIPTION
Hello,
I needed to use JSON_FORCE_OBJECT in a project and noticed there was no support for the json_encode $options parameter. The phpdoc is a copy paste from json_encode documentation.
Cheers
Romain 
