### PR TITLE
Don't override the user's debug configuration

### DIFF
--- a/jsonAPI/JsonApiMiddleware.php
+++ b/jsonAPI/JsonApiMiddleware.php
@@ -30,7 +30,6 @@ class JsonApiMiddleware extends \Slim\Middleware {
     function __construct(){
 
         $app = \Slim\Slim::getInstance();
-        $app->config('debug', false);
 
         // Mirrors the API request
         $app->get('/return', function() use ($app) {


### PR DESCRIPTION
In case they want to see the trace route for errors while in debug environments.