### PR TITLE
Support custom exception error code as status code

### DIFF
--- a/jsonAPI/JsonApiMiddleware.php
+++ b/jsonAPI/JsonApiMiddleware.php
@@ -45,9 +45,14 @@ class JsonApiMiddleware extends \Slim\Middleware {
 
         // Generic error handler
         $app->error(function (Exception $e) use ($app) {
-
-
-            $app->render(500,array(
+            
+            if ($e->getCode()) {
+                $errorCode = $e->getCode();
+            } else {
+                $errorCode = 500;
+            }
+            
+            $app->render($errorCode,array(
                 'error' => true,
                 'msg'   => \JsonApiMiddleware::_errorType($e->getCode()) .": ". $e->getMessage(),
             ));


### PR DESCRIPTION
You don't want to return 500 status on every type of error. This supports a custom status code returned when throwing an exception and defaults to 500 if empty.

For example:

```
throw new \Exception($e->getFullMessage(), 405);
```