### PR TITLE
Add optional containers for response data and metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,32 @@ You can optionally throw exceptions, the middleware will catch all exceptions an
 
 ```
 
+##Embedding response data and metadata in separate containers
+It is possible to separate response metadata and business information in separate containers.
+
+####To make it possible just init JsonApiView with containers names
+```php
+   require 'vendor/autoload.php';
+
+    $app = new \Slim\Slim();
+
+    $app->view(new \JsonApiView("data", "meta"));
+    $app->add(new \JsonApiMiddleware());
+```
+
+####Response
+```json
+{
+    "data":{
+        "msg":"welcome to my API!"
+    },
+    "meta":{
+        "error":false,
+        "status":200
+    }
+}
+```
+
 
 ##routing specific requests to the API
 If your site is using regular HTML responses and you just want to expose an API point on a specific route,

--- a/jsonAPI/JsonApiMiddleware.php
+++ b/jsonAPI/JsonApiMiddleware.php
@@ -53,7 +53,6 @@ class JsonApiMiddleware extends \Slim\Middleware {
             }
             
             $app->render($errorCode,array(
-                'error' => true,
                 'msg'   => \JsonApiMiddleware::_errorType($e->getCode()) .": ". $e->getMessage(),
             ));
         });
@@ -61,7 +60,6 @@ class JsonApiMiddleware extends \Slim\Middleware {
         // Not found handler (invalid routes, invalid method types)
         $app->notFound(function() use ($app) {
             $app->render(404,array(
-                'error' => TRUE,
                 'msg'   => 'Invalid route',
             ));
         });
@@ -76,7 +74,6 @@ class JsonApiMiddleware extends \Slim\Middleware {
 
             if (strlen($app->response()->body()) == 0) {
                 $app->render(500,array(
-                    'error' => TRUE,
                     'msg'   => 'Empty response',
                 ));
             }

--- a/jsonAPI/JsonApiView.php
+++ b/jsonAPI/JsonApiView.php
@@ -46,29 +46,73 @@ class JsonApiView extends \Slim\View {
      * @var string
      */
     public $contentType = 'application/json';
+    
+    /**
+     *
+     * @var string
+     */
+    private $dataWraper;
+    
+    /**
+     *
+     * @var string
+     */
+    private $metaWrapper;
+
+
+    /**
+     * Construct JsonApiView instance
+     * @param type $dataWrapper (optional) Wrapper for data in response
+     * @param type $metaWrapper (optional) Wrapper for metadata in response
+     */
+    public function __construct($dataWrapper = NULL, $metaWrapper = NULL) {
+        parent::__construct();
+        $this->dataWraper = $dataWrapper;
+        $this->metaWrapper = $metaWrapper;
+    }
 
     public function render($status=200, $data = NULL) {
         $app = \Slim\Slim::getInstance();
 
         $status = intval($status);
 
-        $response = $this->all();
+        if ($this->dataWraper) {
+            $response[$this->dataWraper]=  $this->all();
+        } else {
+            $response = $this->all();
+        }
 
         //append error bool
         if (!$this->has('error')) {
-            $response['error'] = false;
+            if ($this->metaWrapper) {
+                $response[$this->metaWrapper]['error'] = false;
+            } else {
+                $response['error'] = false;
+            }
         }
 
         //append status code
-        $response['status'] = $status;
+        if ($this->metaWrapper) {
+            $response[$this->metaWrapper]['status'] = $status;
+            } else {
+            $response['status'] = $status;
+        }
 
 		//add flash messages
 		if(isset($this->data->flash) && is_object($this->data->flash)){
 		    $flash = $this->data->flash->getMessages();
             if (count($flash)) {
-                $response['flash'] = $flash;   
+                if ($this->metaWrapper) {
+                    $response[$this->metaWrapper]['flash'] = $flash;
+                } else {
+                    $response['flash'] = $flash;
+                }
             } else {
-                unset($response['flash']);
+                if ($this->metaWrapper) {
+                    unset($response[$this->metaWrapper]['flash']);
+                } else {
+                    unset($response['flash']);
+                }
             }
 		}
 		

--- a/jsonAPI/JsonApiView.php
+++ b/jsonAPI/JsonApiView.php
@@ -83,11 +83,17 @@ class JsonApiView extends \Slim\View {
         }
 
         //append error bool
-        if (!$this->has('error')) {
+        if ($status<400) {
             if ($this->metaWrapper) {
                 $response[$this->metaWrapper]['error'] = false;
             } else {
                 $response['error'] = false;
+            }
+        } else {
+            if ($this->metaWrapper) {
+                $response[$this->metaWrapper]['error'] = true;
+            } else {
+                $response['error'] = true;
             }
         }
 
@@ -98,20 +104,24 @@ class JsonApiView extends \Slim\View {
             $response['status'] = $status;
         }
 
-	//add flash messages
-	if(isset($this->data->flash) && is_object($this->data->flash)){
-		    $flash = $this->data->flash->getMessages();
+        //add flash messages
+        if (isset($this->data->flash) && is_object($this->data->flash)) {
+            $flash = $this->data->flash->getMessages();
             if (count($flash)) {
                 if ($this->metaWrapper) {
-                    unset($response['flash']);
+                    unset($response[$this->dataWraper]['flash']);
                     $response[$this->metaWrapper]['flash'] = $flash;
                 } else {
                     $response['flash'] = $flash;
                 }
             } else {
-                unset($response['flash']);
+                if ($this->metaWrapper) {
+                    unset($response[$this->dataWraper]['flash']);
+                } else {
+                    unset($response['flash']);
+                }
             }
-	}
+        }
 		
         $app->response()->status($status);
         $app->response()->header('Content-Type', $this->contentType);

--- a/jsonAPI/JsonApiView.php
+++ b/jsonAPI/JsonApiView.php
@@ -98,23 +98,20 @@ class JsonApiView extends \Slim\View {
             $response['status'] = $status;
         }
 
-		//add flash messages
-		if(isset($this->data->flash) && is_object($this->data->flash)){
+	//add flash messages
+	if(isset($this->data->flash) && is_object($this->data->flash)){
 		    $flash = $this->data->flash->getMessages();
             if (count($flash)) {
                 if ($this->metaWrapper) {
+                    unset($response['flash']);
                     $response[$this->metaWrapper]['flash'] = $flash;
                 } else {
                     $response['flash'] = $flash;
                 }
             } else {
-                if ($this->metaWrapper) {
-                    unset($response[$this->metaWrapper]['flash']);
-                } else {
-                    unset($response['flash']);
-                }
+                unset($response['flash']);
             }
-		}
+	}
 		
         $app->response()->status($status);
         $app->response()->header('Content-Type', $this->contentType);


### PR DESCRIPTION
It is usual case to format json outtpus with split metadata(status code, error boolean) and business information. This is optional. So backwards capability keept.

Example:
Initialization
```php
   require 'vendor/autoload.php';

    $app = new \Slim\Slim();

    $app->view(new \JsonApiView("data", "meta"));
    $app->add(new \JsonApiMiddleware());
```
Request
```php

    $app->get('/', function() use ($app) {
        $app->render(200,array(
                'msg' => 'welcome to my API!',
            ));
    });

```
Response
```json
{
    "data":{
        "msg":"welcome to my API!"
    },
    "meta":{
        "error":false,
        "status":200
    }
}
```