### PR TITLE
Add filename and line on log message but not on return message

### DIFF
--- a/jsonAPI/JsonApiMiddleware.php
+++ b/jsonAPI/JsonApiMiddleware.php
@@ -54,10 +54,10 @@ class JsonApiMiddleware extends \Slim\Middleware {
 
             // Log error with the same message
             $message = \JsonApiMiddleware::_errorType($e->getCode()) .": ". $e->getMessage();
-            $app->getLog()->error($message);
-            
+            $app->getLog()->error($message . ' in ' . $e->getFile() . ' at line ' . $e->getLine());
+
             $app->render($errorCode,array(
-                'msg'   => $message,
+                'msg' => $message,
             ));
         });
 


### PR DESCRIPTION
Hello,

I complete my feature to add filename and line on log file message but not on return message API.

Thanks, bye.